### PR TITLE
PhysBoneからSpringBoneへのパラメーター変換を修正

### DIFF
--- a/SwayingObjects/DynamicBoneParameters.cs
+++ b/SwayingObjects/DynamicBoneParameters.cs
@@ -15,5 +15,7 @@ namespace Esperecyan.UniVRMExtensions.SwayingObjects
         public AnimationCurve StiffnessDistrib = null;
         public float Inert = 0;
         public AnimationCurve InertDistrib = null;
+        public Vector3 Gravity = new Vector3(0, 0, 0);
+
     }
 }

--- a/SwayingObjects/DynamicBonesToVRMSpringBonesConverter.cs
+++ b/SwayingObjects/DynamicBonesToVRMSpringBonesConverter.cs
@@ -42,6 +42,8 @@ namespace Esperecyan.UniVRMExtensions.SwayingObjects
             {
                 StiffnessForce = dynamicBoneParameters.Elasticity / 0.05f,
                 DragForce = dynamicBoneParameters.Damping / 0.6f,
+                GravityPower = dynamicBoneParameters.Gravity.magnitude,
+                GravityDir = dynamicBoneParameters.Gravity.normalized,
             };
         }
 
@@ -201,6 +203,7 @@ namespace Esperecyan.UniVRMExtensions.SwayingObjects
                         StiffnessDistrib = dynamicBone.m_StiffnessDistrib,
                         Inert = dynamicBone.m_Inert,
                         InertDistrib = dynamicBone.m_InertDistrib,
+                        Gravity = dynamicBone.m_Gravity,
                     }, new BoneInfo(converter.Destination.GetComponent<VRMMeta>(), comment: ""));
 
                     var destinationColliderGroups = new List<VRMSpringBoneColliderGroup>();
@@ -242,13 +245,13 @@ namespace Esperecyan.UniVRMExtensions.SwayingObjects
                         }
                     }
 
-                    Vector3 gravity = dynamicBone.m_Gravity;
                     return (dynamicBone, parameters, destinationColliderGroups, compare: string.Join("\n", new[]
                     {
                         parameters.StiffnessForce,
-                        gravity.x,
-                        gravity.y,
-                        gravity.z,
+                        parameters.GravityPower,
+                        parameters.GravityDir.x,
+                        parameters.GravityDir.y,
+                        parameters.GravityDir.z,
                         parameters.DragForce,
                         TransformUtilities.CalculateDistance(dynamicBone.transform, dynamicBone.m_Radius),
                 }.Select(parameter => parameter.ToString("F2"))
@@ -264,9 +267,8 @@ namespace Esperecyan.UniVRMExtensions.SwayingObjects
                     ? converter.Secondary.AddComponent<VRMSpringBone>()
                     : Undo.AddComponent<VRMSpringBone>(converter.Secondary);
                 vrmSpringBone.m_stiffnessForce = dynamicBone.parameters.StiffnessForce;
-                Vector3 gravity = dynamicBone.dynamicBone.m_Gravity;
-                vrmSpringBone.m_gravityPower = gravity.magnitude;
-                vrmSpringBone.m_gravityDir = gravity.normalized;
+                vrmSpringBone.m_gravityPower = dynamicBone.parameters.GravityPower;
+                vrmSpringBone.m_gravityDir = dynamicBone.parameters.GravityDir;
                 vrmSpringBone.m_dragForce = dynamicBone.parameters.DragForce;
                 vrmSpringBone.RootBones = dynamicBones.Select(db => (Transform)db.dynamicBone.m_Root)
                     .Where(sourceBone => sourceBone != null && sourceBone.IsChildOf(converter.Source.transform))

--- a/SwayingObjects/VRCPhysBoneParameters.cs
+++ b/SwayingObjects/VRCPhysBoneParameters.cs
@@ -10,20 +10,21 @@ namespace Esperecyan.UniVRMExtensions.SwayingObjects
     /// </summary>
     public class VRCPhysBoneParameters
     {
-        private static readonly float DefaultStiffness = 0.2f;
+
+#if VRC_SDK_VRCSDK3
+        public IntegrationType IntegrationType = IntegrationType.Simplified;
+#endif
 
         public float Pull = 0.2f;
         public AnimationCurve PullCurve = null;
-#if VRC_SDK_VRCSDK3
-        internal IntegrationType IntegrationType =>
-            this.Spring == VRCPhysBoneParameters.DefaultStiffness && this.StiffnessCurve == null
-                ? IntegrationType.Simplified
-                : IntegrationType.Advanced;
-#endif
         public float Spring = 0.2f;
         public AnimationCurve SpringCurve = null;
-        public float Stiffness = VRCPhysBoneParameters.DefaultStiffness;
+        public float Stiffness = 0.2f;
         public AnimationCurve StiffnessCurve = null;
+        public float Gravity = 0;
+        public AnimationCurve GravityCurve = null;
+        public float GravityFalloff = 0;
+        public AnimationCurve GravityFalloffCurve = null;
 #if VRC_SDK_VRCSDK3
         public ImmobileType ImmobileType;
 #endif

--- a/SwayingObjects/VRCPhysBonesToVRMSpringBonesConverter.cs
+++ b/SwayingObjects/VRCPhysBonesToVRMSpringBonesConverter.cs
@@ -41,8 +41,8 @@ namespace Esperecyan.UniVRMExtensions.SwayingObjects
         {
             return new VRMSpringBoneParameters()
             {
-                StiffnessForce = vrcPhysBoneParameters.Pull / 0.075f,
-                DragForce = vrcPhysBoneParameters.Spring / 0.2f,
+                StiffnessForce = vrcPhysBoneParameters.Pull * 4.0f,
+                DragForce = vrcPhysBoneParameters.Spring,
                 GravityPower = vrcPhysBoneParameters.Gravity * 20.0f,
             };
         }

--- a/SwayingObjects/VRCPhysBonesToVRMSpringBonesConverter.cs
+++ b/SwayingObjects/VRCPhysBonesToVRMSpringBonesConverter.cs
@@ -43,6 +43,7 @@ namespace Esperecyan.UniVRMExtensions.SwayingObjects
             {
                 StiffnessForce = vrcPhysBoneParameters.Pull / 0.075f,
                 DragForce = vrcPhysBoneParameters.Spring / 0.2f,
+                GravityPower = vrcPhysBoneParameters.Gravity * 20.0f,
             };
         }
 
@@ -224,6 +225,9 @@ namespace Esperecyan.UniVRMExtensions.SwayingObjects
                         SpringCurve = vrcPhysBone.springCurve,
                         Stiffness = vrcPhysBone.stiffness,
                         StiffnessCurve = vrcPhysBone.stiffnessCurve,
+                        Gravity = vrcPhysBone.gravity,
+                        GravityFalloff = vrcPhysBone.gravityFalloff,
+                        GravityFalloffCurve = vrcPhysBone.gravityFalloffCurve,
 #if VRC_SDK_VRCSDK3
                         ImmobileType = vrcPhysBone.immobileType,
 #endif
@@ -298,7 +302,7 @@ namespace Esperecyan.UniVRMExtensions.SwayingObjects
                     return (vrcPhysBone, parameters, destinationColliderGroups, compare: string.Join("\n", new[]
                     {
                         parameters.StiffnessForce,
-                        vrcPhysBone.gravity,
+                        parameters.GravityPower,
                         parameters.DragForce,
                         TransformUtilities.CalculateDistance(vrcPhysBone.transform, vrcPhysBone.radius),
                 }.Select(parameter => parameter.ToString("F2"))
@@ -316,7 +320,8 @@ namespace Esperecyan.UniVRMExtensions.SwayingObjects
                     : Undo.AddComponent<VRMSpringBone>(converter.Secondary);
                 vrmSpringBone.m_comment = vrcPhysBone.vrcPhysBone.parameter;
                 vrmSpringBone.m_stiffnessForce = vrcPhysBone.parameters.StiffnessForce;
-                vrmSpringBone.m_gravityPower = vrcPhysBone.vrcPhysBone.gravity / 0.05f;
+                vrmSpringBone.m_gravityPower = vrcPhysBone.parameters.GravityPower;
+                vrmSpringBone.m_gravityDir = vrcPhysBone.parameters.GravityDir;
                 vrmSpringBone.m_dragForce = vrcPhysBone.parameters.DragForce;
                 vrmSpringBone.RootBones = vrcPhysBones
                     .Select(db => (/* SDK3未インポート用 */Transform)

--- a/SwayingObjects/VRMSpringBoneParameters.cs
+++ b/SwayingObjects/VRMSpringBoneParameters.cs
@@ -1,3 +1,4 @@
+using UnityEngine;
 
 namespace Esperecyan.UniVRMExtensions.SwayingObjects
 {
@@ -7,6 +8,8 @@ namespace Esperecyan.UniVRMExtensions.SwayingObjects
     public class VRMSpringBoneParameters
     {
         public float StiffnessForce = 1.0f;
+        public float GravityPower = 0.0f;
+        public Vector3 GravityDir = new Vector3(0, -1.0f, 0);
         public float DragForce = 0.4f;
     }
 }

--- a/SwayingObjects/VRMSpringBonesToDynamicBonesConverter.cs
+++ b/SwayingObjects/VRMSpringBonesToDynamicBonesConverter.cs
@@ -43,6 +43,7 @@ namespace Esperecyan.UniVRMExtensions.SwayingObjects
                 Damping = vrmSpringBoneParameters.DragForce * 0.6f,
                 Stiffness = 0,
                 Inert = 0,
+                Gravity = vrmSpringBoneParameters.GravityPower * vrmSpringBoneParameters.GravityDir,
             };
         }
 
@@ -128,6 +129,8 @@ namespace Esperecyan.UniVRMExtensions.SwayingObjects
                     {
                         StiffnessForce = vrmSpringBone.m_stiffnessForce,
                         DragForce = vrmSpringBone.m_dragForce,
+                        GravityDir = vrmSpringBone.m_gravityDir,
+                        GravityPower = vrmSpringBone.m_gravityPower,
                     };
                     var boneInfo = new BoneInfo(converter.Source.GetComponent<VRMMeta>(), vrmSpringBone.m_comment);
 
@@ -163,9 +166,9 @@ namespace Esperecyan.UniVRMExtensions.SwayingObjects
                             dynamicBone.m_StiffnessDistrib = dynamicBoneParameters.StiffnessDistrib;
                             dynamicBone.m_Inert = dynamicBoneParameters.Inert;
                             dynamicBone.m_InertDistrib = dynamicBoneParameters.InertDistrib;
+                            dynamicBone.m_Gravity = dynamicBoneParameters.Gravity;
                         }
 
-                        dynamicBone.m_Gravity = vrmSpringBone.m_gravityDir * vrmSpringBone.m_gravityPower;
                         dynamicBone.m_Radius = TransformUtilities.CalculateDistance(
                             vrmSpringBone.transform,
                             vrmSpringBone.m_hitRadius,

--- a/SwayingObjects/VRMSpringBonesToVRCPhysBonesConverter.cs
+++ b/SwayingObjects/VRMSpringBonesToVRCPhysBonesConverter.cs
@@ -41,8 +41,8 @@ namespace Esperecyan.UniVRMExtensions.SwayingObjects
         {
             return new VRCPhysBoneParameters()
             {
-                Pull = vrmSpringBoneParameters.StiffnessForce * 0.075f,
-                Spring = vrmSpringBoneParameters.DragForce * 0.2f,
+                Pull = vrmSpringBoneParameters.StiffnessForce / 4.0f,
+                Spring = vrmSpringBoneParameters.DragForce,
                 Stiffness = 0,
                 Gravity = vrmSpringBoneParameters.GravityPower / 20.0f,
                 // 移動時に揺れないように

--- a/SwayingObjects/VRMSpringBonesToVRCPhysBonesConverter.cs
+++ b/SwayingObjects/VRMSpringBonesToVRCPhysBonesConverter.cs
@@ -44,6 +44,7 @@ namespace Esperecyan.UniVRMExtensions.SwayingObjects
                 Pull = vrmSpringBoneParameters.StiffnessForce * 0.075f,
                 Spring = vrmSpringBoneParameters.DragForce * 0.2f,
                 Stiffness = 0,
+                Gravity = vrmSpringBoneParameters.GravityPower / 20.0f,
                 // 移動時に揺れないように
 #if VRC_SDK_VRCSDK3
                 ImmobileType = VRCPhysBoneBase.ImmobileType.World,
@@ -147,6 +148,8 @@ namespace Esperecyan.UniVRMExtensions.SwayingObjects
                     {
                         StiffnessForce = vrmSpringBone.m_stiffnessForce,
                         DragForce = vrmSpringBone.m_dragForce,
+                        GravityDir = vrmSpringBone.m_gravityDir,
+                        GravityPower = vrmSpringBone.m_gravityPower,
                     };
                     var boneInfo = new BoneInfo(converter.Source.GetComponent<VRMMeta>(), vrmSpringBone.m_comment);
 
@@ -179,15 +182,17 @@ namespace Esperecyan.UniVRMExtensions.SwayingObjects
                         }
                         if (vrcPhaysBoneParameters != null)
                         {
-                            vrcPhysBone.pull = vrcPhaysBoneParameters.Pull;
-                            vrcPhysBone.pullCurve = vrcPhaysBoneParameters.PullCurve;
 #if VRC_SDK_VRCSDK3
                             vrcPhysBone.integrationType = vrcPhaysBoneParameters.IntegrationType;
 #endif
+                            vrcPhysBone.pull = vrcPhaysBoneParameters.Pull;
+                            vrcPhysBone.pullCurve = vrcPhaysBoneParameters.PullCurve;
                             vrcPhysBone.spring = vrcPhaysBoneParameters.Spring;
                             vrcPhysBone.springCurve = vrcPhaysBoneParameters.SpringCurve;
                             vrcPhysBone.stiffness = vrcPhaysBoneParameters.Stiffness;
                             vrcPhysBone.stiffnessCurve = vrcPhaysBoneParameters.StiffnessCurve;
+                            vrcPhysBone.gravity = vrcPhaysBoneParameters.Gravity;
+                            vrcPhysBone.gravityCurve = vrcPhaysBoneParameters.GravityCurve;
 #if VRC_SDK_VRCSDK3
                             vrcPhysBone.immobileType = vrcPhaysBoneParameters.ImmobileType;
 #endif
@@ -198,7 +203,6 @@ namespace Esperecyan.UniVRMExtensions.SwayingObjects
                             vrcPhysBone.maxStretchCurve = vrcPhaysBoneParameters.MaxStretchCurve;
                         }
 
-                        vrcPhysBone.gravity = vrmSpringBone.m_gravityPower * 0.05f;
                         vrcPhysBone.radius = TransformUtilities.CalculateDistance(
                             vrmSpringBone.transform,
                             vrmSpringBone.m_hitRadius,

--- a/SwayingObjects/Wizard.cs
+++ b/SwayingObjects/Wizard.cs
@@ -344,6 +344,7 @@ namespace Esperecyan.UniVRMExtensions.SwayingObjects
         {
             StiffnessForce = vrcPhysBoneParameters.Pull / 0.075f,
             DragForce = vrcPhysBoneParameters.Spring / 0.2f,
+            GravityPower = vrcPhysBoneParameters.Gravity * 20.0f,
         };
     }";
                     break;
@@ -358,6 +359,7 @@ namespace Esperecyan.UniVRMExtensions.SwayingObjects
             {
                 Pull = vrmSpringBoneParameters.StiffnessForce * 0.075f,
                 Spring = vrmSpringBoneParameters.DragForce * 0.2f,
+                Gravity = vrmSpringBoneParameters.GravityPower / 20.0f;
                 Immobile = 0,
             };
         }
@@ -374,6 +376,8 @@ namespace Esperecyan.UniVRMExtensions.SwayingObjects
         {
             StiffnessForce = dynamicBoneParameters.Elasticity / 0.05f,
             DragForce = dynamicBoneParameters.Damping / 0.6f,
+            GravityPower = dynamicBoneParameters.Gravity.magnitude,
+            GravityDir = dynamicBoneParameters.Gravity.normalized,
         };
     }";
                     break;
@@ -390,6 +394,7 @@ namespace Esperecyan.UniVRMExtensions.SwayingObjects
             Damping = vrmSpringBoneParameters.DragForce * 0.6f,
             Stiffness = 0,
             Inert = 0,
+            Gravity = vrmSpringBoneParameters.GravityPower * vrmSpringBoneParameters.GravityDir,
         };
     }";
                     break;

--- a/SwayingObjects/Wizard.cs
+++ b/SwayingObjects/Wizard.cs
@@ -342,8 +342,8 @@ namespace Esperecyan.UniVRMExtensions.SwayingObjects
     {
         return new VRMSpringBoneParameters()
         {
-            StiffnessForce = vrcPhysBoneParameters.Pull / 0.075f,
-            DragForce = vrcPhysBoneParameters.Spring / 0.2f,
+            StiffnessForce = vrcPhysBoneParameters.Pull * 4.0f,
+            DragForce = vrcPhysBoneParameters.Spring,
             GravityPower = vrcPhysBoneParameters.Gravity * 20.0f,
         };
     }";
@@ -357,8 +357,8 @@ namespace Esperecyan.UniVRMExtensions.SwayingObjects
     {
             return new VRCPhysBoneParameters()
             {
-                Pull = vrmSpringBoneParameters.StiffnessForce * 0.075f,
-                Spring = vrmSpringBoneParameters.DragForce * 0.2f,
+                Pull = vrmSpringBoneParameters.StiffnessForce / 4.0f,
+                Spring = vrmSpringBoneParameters.DragForce,
                 Gravity = vrmSpringBoneParameters.GravityPower / 20.0f;
                 Immobile = 0,
             };


### PR DESCRIPTION
* Pullが0～1に対して、StiffnessForceは0～4。強度の変換はガンマ変換に変更。
* Springが0～1に対して、DragForceは0～1。強度の変換はガンマ変換に変更。(DragForceが1を超えると暴れていました。)
* Gravityの値をパラメータ変換アルゴリズムで制御できていなかったのでパラメータに追加。
* コライダーの高さ方向が誤っていたので修正。